### PR TITLE
fix: fix links in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,14 +4,14 @@ Ganache network provider plugin for Ape. Ganache is a tool for creating a local 
 
 ## Dependencies
 
-* `python3 <https://www.python.org/downloads>`_ version 3.7 or greater, python3-dev
-* Node.js, NPM, and Ganache. See Ganache's `Installation <https://github.com/trufflesuite/ganache#command-line-use>`_ documentation for steps.
+* [python3](https://www.python.org/downloads) version 3.7.2 or greater, python3-dev
+* Node.js, NPM, and Ganache. See Ganache's [Installation](https://github.com/trufflesuite/ganache#command-line-use>) documentation for steps.
 
 ## Installation
 
 ### via ``pip``
 
-You can install the latest release via `pip <https://pypi.org/project/pip/>`_:
+You can install the latest release via [pip](https://pypi.org/project/pip/):
 
 ```bash
 pip install ape-ganache
@@ -19,7 +19,7 @@ pip install ape-ganache
 
 ### via ``setuptools``
 
-You can clone the repository and use `setuptools <https://github.com/pypa/setuptools>`_ for the most up-to-date version:
+You can clone the repository and use [setuptools](https://github.com/pypa/setuptools) for the most up-to-date version:
 
 ```bash
 git clone https://github.com/ApeWorX/ape-ganache.git

--- a/ape_ganache/providers.py
+++ b/ape_ganache/providers.py
@@ -81,7 +81,7 @@ class GanacheProvider(SubprocessProvider, Web3Provider, TestProviderAPI):
 
     @property
     def process_name(self) -> str:
-        return "Ganache node"
+        return "Ganache"
 
     @cached_property
     def ganache_bin(self) -> str:


### PR DESCRIPTION
### What I did

The links in the README were not working.

### How I did it

Uses markdown links instead of rst

### How to verify it

Links works

### Checklist

- [ ] Passes all linting checks (pre-commit and CI jobs)
- [ ] New test cases have been added and are passing
- [ ] Documentation has been updated
- [ ] PR title follows [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) standard (will be automatically included in the changelog)
