### PR TITLE
fix: update web3 isConnected()

### DIFF
--- a/ape_ganache/providers.py
+++ b/ape_ganache/providers.py
@@ -157,7 +157,7 @@ class GanacheProvider(SubprocessProvider, Web3Provider, TestProviderAPI):
             return
 
         self._web3 = Web3(HTTPProvider(self.uri))
-        if not self._web3.isConnected():
+        if not self._web3.is_connected():
             self._web3 = None
             return
 

--- a/setup.py
+++ b/setup.py
@@ -67,7 +67,7 @@ setup(
     url="https://github.com/ApeWorX/ape-ganache",
     include_package_data=True,
     install_requires=[
-        "eth-ape>=0.5.0,<0.6",
+        "eth-ape>=0.5.2,<0.6",
     ],
     python_requires=">=3.8,<4",
     extras_require=extras_require,


### PR DESCRIPTION
This is needed as a companion to https://github.com/ApeWorX/ape/pull/1082 since the plugin uses ape's web3 dependency