### PR TITLE
Fixes problem about getting correct revert string

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -15,7 +15,7 @@ repos:
       - id: black
         name: black
 
--   repo: https://gitlab.com/pycqa/flake8
+-   repo: https://github.com/PyCQA/flake8
     rev: 4.0.1
     hooks:
     -   id: flake8

--- a/ape_ganache/providers.py
+++ b/ape_ganache/providers.py
@@ -267,6 +267,9 @@ class GanacheProvider(SubprocessProvider, Web3Provider, TestProviderAPI):
         receipt.raise_for_status()
         return receipt
 
+    def get_virtual_machine_error(self, exception: Exception) -> VirtualMachineError:
+        return _get_vm_error(exception)
+
 
 class GanacheMainnetForkProvider(GanacheProvider):
     """
@@ -337,7 +340,7 @@ class GanacheMainnetForkProvider(GanacheProvider):
         return cmd
 
 
-def _get_vm_error(web3_value_error: ValueError) -> TransactionError:
+def _get_vm_error(web3_value_error: Exception) -> TransactionError:
     if not len(web3_value_error.args):
         return VirtualMachineError(base_err=web3_value_error)
 
@@ -351,9 +354,7 @@ def _get_vm_error(web3_value_error: ValueError) -> TransactionError:
 
     # Handle `ContactLogicError` similarly to other providers in `ape`.
     # by stripping off the unnecessary prefix that ganache has on reverts.
-    ganache_prefix = (
-        "Error: VM Exception while processing transaction: reverted with reason string "
-    )
+    ganache_prefix = "VM Exception while processing transaction: revert "
     if message.startswith(ganache_prefix):
         message = message.replace(ganache_prefix, "").strip("'")
         return ContractLogicError(revert_message=message)

--- a/tests/test_ganache.py
+++ b/tests/test_ganache.py
@@ -1,4 +1,5 @@
 import pytest
+from ape.exceptions import ContractLogicError
 from hexbytes import HexBytes
 
 from ape_ganache.exceptions import GanacheProviderError
@@ -138,3 +139,13 @@ def test_snapshot_and_revert(ganache_connected):
 @pytest.mark.xfail(reason="Ganache doesn't support *_impersonateAccount yet.")
 def test_unlock_account(ganache_connected):
     assert ganache_connected.unlock_account(TEST_WALLET_ADDRESS) is True
+
+
+def test_get_vm_error(ganache_connected):
+    err = ValueError(
+        {"message": "VM Exception while processing transaction: revert Not authorized"}
+    )
+    error = ganache_connected.get_virtual_machine_error(err)
+
+    assert isinstance(error, ContractLogicError)
+    assert error.revert_message == "Not authorized"


### PR DESCRIPTION
### What I did

Solved the problem of not getting revert string.

### How I did it

Changed the ganache suffix and implemented get_virtual_machine_error to use existing _get_vm_error function.

### How to verify it

Just run tests.

### Checklist

- [ ] Passes all linting checks (pre-commit and CI jobs)
- [ ] New test cases have been added and are passing
- [ ] Documentation has been updated
- [ ] PR title follows [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) standard (will be automatically included in the changelog)
