### PR TITLE
feat: add unlock_account to the provider

### DIFF
--- a/ape_ganache/provider.py
+++ b/ape_ganache/provider.py
@@ -14,7 +14,7 @@ from ape.api import (
 )
 from ape.exceptions import ContractLogicError, ProviderError, SubprocessError, VirtualMachineError
 from ape.logging import logger
-from ape.types import SnapshotID
+from ape.types import AddressType, SnapshotID
 from ape.utils import cached_property
 from ape_test import Config as TestConfig
 from evm_trace import CallTreeNode, CallType, TraceFrame, get_calltree_from_geth_trace
@@ -320,6 +320,10 @@ class GanacheProvider(SubprocessProvider, Web3Provider, TestProviderAPI):
             message = message.replace("revert ", "")
 
         return ContractLogicError(revert_message=message)
+
+    def unlock_account(self, address: AddressType) -> bool:
+        self._make_request("evm_addAccount", [address, ""])
+        return self._make_request("personal_unlockAccount", [address, "", 9999999999])
 
 
 class GanacheForkProvider(GanacheProvider):

--- a/tests/test_fork_provider.py
+++ b/tests/test_fork_provider.py
@@ -2,6 +2,7 @@ import tempfile
 from pathlib import Path
 
 import pytest
+from ape.api.accounts import ImpersonatedAccount
 from ape.exceptions import ContractLogicError
 from ape_ethereum.ecosystem import NETWORKS
 
@@ -93,3 +94,24 @@ def test_get_receipt(mainnet_fork_provider, mainnet_fork_contract_instance, owne
     assert receipt.txn_hash == actual.txn_hash
     assert actual.receiver == mainnet_fork_contract_instance.address
     assert actual.sender == receipt.sender
+
+
+@pytest.mark.fork
+def test_unlock_account_with_multiple_providers(
+    networks, connected_provider, mainnet_fork_port, goerli_fork_port
+):
+
+    with networks.ethereum.mainnet_fork.use_provider(
+        "ganache", provider_settings={"port": mainnet_fork_port}
+    ):
+        imp_acc = connected_provider.account_manager[TEST_ADDRESS]
+        assert isinstance(imp_acc, ImpersonatedAccount)
+
+        with networks.ethereum.goerli_fork.use_provider(
+            "ganache", provider_settings={"port": goerli_fork_port}
+        ):
+            imp_acc = connected_provider.account_manager[TEST_ADDRESS]
+            assert isinstance(imp_acc, ImpersonatedAccount)
+
+    imp_acc = connected_provider.account_manager[TEST_ADDRESS]
+    assert isinstance(imp_acc, ImpersonatedAccount)

--- a/tests/test_gas_report.py
+++ b/tests/test_gas_report.py
@@ -13,6 +13,7 @@ TOKEN_B_GAS_REPORT = r"""
   Method +Times called +Min. +Max. +Mean +Median
  ─+
   balanceOf +\d +\d+ + \d+ + \d+ + \d+
+  transfer +\d +\d+ + \d+ + \d+ + \d+
 """
 EXPECTED_GAS_REPORT = rf"""
  +TestContractVy Gas
@@ -21,18 +22,19 @@ EXPECTED_GAS_REPORT = rf"""
  ─+
   myNumber +\d +\d+ + \d+ + \d+ + \d+
   setNumber +\d +\d+ + \d+ + \d+ + \d+
+  fooAndBar +\d +\d+ + \d+ + \d+ + \d+
 
  +TokenA Gas
 
   Method +Times called +Min. +Max. +Mean +Median
  ─+
   balanceOf +\d +\d+ + \d+ + \d+ + \d+
+  transfer +\d +\d+ + \d+ + \d+ + \d+
 {TOKEN_B_GAS_REPORT}
 """
 
 
-def filter_expected_methods(*methods_to_remove: str) -> str:
-    expected = EXPECTED_GAS_REPORT
+def filter_expected_methods(expected, *methods_to_remove: str) -> str:
     for name in methods_to_remove:
         line = f"\n  {name} +\\d +\\d+ + \\d+ + \\d+ + \\d+"
         expected = expected.replace(line, "")
@@ -77,8 +79,9 @@ def test_gas_flag_in_tests(ape_pytester):
 
 def test_gas_flag_exclude_method_using_cli_option(ape_pytester):
     # NOTE: Includes both a mutable and a view method.
-    expected = filter_expected_methods("fooAndBar", "myNumber")
+    expected = filter_expected_methods(EXPECTED_GAS_REPORT, "fooAndBar", "setNumber")
     # Also ensure can filter out whole class
     expected = expected.replace(TOKEN_B_GAS_REPORT, "")
-    result = ape_pytester.runpytest("--gas", "--gas-exclude", "*:fooAndBar,*:myNumber,tokenB:*")
+    expected = filter_expected_methods(expected, "transfer")
+    result = ape_pytester.runpytest("--gas", "--gas-exclude", "*:fooAndBar,*:setNumber,TokenB:*")
     run_gas_test(result, expected_report=expected)

--- a/tests/test_provider.py
+++ b/tests/test_provider.py
@@ -3,6 +3,7 @@ import tempfile
 from pathlib import Path
 
 import pytest
+from ape.api.accounts import ImpersonatedAccount
 from ape.exceptions import ContractLogicError, SignatureError
 from evm_trace import CallTreeNode, CallType
 
@@ -151,3 +152,9 @@ def test_get_receipt(connected_provider, contract_instance, owner):
     assert receipt.txn_hash == actual.txn_hash
     assert actual.receiver == contract_instance.address
     assert actual.sender == receipt.sender
+
+
+def test_unlock_account(connected_provider):
+    assert TEST_WALLET_ADDRESS not in connected_provider.account_manager
+    ape_account = connected_provider.account_manager[TEST_WALLET_ADDRESS]
+    assert isinstance(ape_account, ImpersonatedAccount)


### PR DESCRIPTION
### What I did

Implemented support for unlocking account in ganache

<!-- The `fixes:` field denotes an issue that will be marked resolved by merging this PR -->
fixes: APE-487

### How I did it

### How to verify it

### Checklist

- [ ] Passes all linting checks (pre-commit and CI jobs)
- [ ] New test cases have been added and are passing
- [ ] Documentation has been updated
- [ ] PR title follows [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) standard (will be automatically included in the changelog)
