### PR TITLE
refactor: remove goerli

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -99,7 +99,6 @@ jobs:
           env:
             # Used in fork tests as well as ape-ens.
             WEB3_ETHEREUM_MAINNET_ALCHEMY_API_KEY: ${{ secrets.WEB3_ETHEREUM_MAINNET_ALCHEMY_API_KEY }}
-            WEB3_ETHEREUM_GOERLI_ALCHEMY_API_KEY: ${{ secrets.WEB3_ETHEREUM_GOERLI_ALCHEMY_API_KEY }}
             WEB3_POLYGON_MUMBAI_ALCHEMY_API_KEY: ${{ secrets.WEB3_POLYGON_MUMBAI_ALCHEMY_API_KEY }}
 
 # NOTE: uncomment this block after you've marked tests with @pytest.mark.fuzzing

--- a/ape_ganache/__init__.py
+++ b/ape_ganache/__init__.py
@@ -25,7 +25,7 @@ def providers():
 
     yield "arbitrum", LOCAL_NETWORK_NAME, GanacheProvider
     yield "arbitrum", "mainnet-fork", GanacheForkProvider
-    yield "arbitrum", "goerli-fork", GanacheForkProvider
+    yield "arbitrum", "sepolia-fork", GanacheForkProvider
 
     yield "avalanche", LOCAL_NETWORK_NAME, GanacheProvider
     yield "avalanche", "mainnet-fork", GanacheForkProvider
@@ -41,7 +41,7 @@ def providers():
 
     yield "optimism", LOCAL_NETWORK_NAME, GanacheProvider
     yield "optimism", "mainnet-fork", GanacheForkProvider
-    yield "optimism", "goerli-fork", GanacheForkProvider
+    yield "optimism", "sepolia-fork", GanacheForkProvider
 
     yield "polygon", LOCAL_NETWORK_NAME, GanacheProvider
     yield "polygon", "mainnet-fork", GanacheForkProvider

--- a/tests/ape-config.yaml
+++ b/tests/ape-config.yaml
@@ -27,13 +27,10 @@ ganache:
       mainnet:
         upstream_provider: alchemy
         block_number: 15776634
-      goerli:
-        upstream_provider: alchemy
-        block_number: 7849922
       sepolia:
         upstream_provider: alchemy
         block_number: 3091950
-  
+
   miner:
     gas_price: 2111222333
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -26,7 +26,7 @@ NAME = "ganache"
 # Needed to test tracing support in core `ape test` command.
 pytest_plugins = ["pytester"]
 MAINNET_FORK_PORT = 9001
-GOERLI_FORK_PORT = 9002
+SEPOLIA_FORK_PORT = 9002
 
 
 def pytest_runtest_makereport(item, call):
@@ -204,14 +204,14 @@ def mainnet_fork_provider(name, networks, mainnet_fork_port):
 
 
 @pytest.fixture
-def goerli_fork_port():
-    return GOERLI_FORK_PORT
+def sepolia_fork_port():
+    return SEPOLIA_FORK_PORT
 
 
 @pytest.fixture
-def goerli_fork_provider(name, networks, goerli_fork_port):
-    with networks.ethereum.goerli_fork.use_provider(
-        name, provider_settings={"port": goerli_fork_port}
+def sepolia_fork_provider(name, networks, sepolia_fork_port):
+    with networks.ethereum.sepolia_fork.use_provider(
+        name, provider_settings={"port": sepolia_fork_port}
     ) as provider:
         yield provider
 

--- a/tests/test_fork_provider.py
+++ b/tests/test_fork_provider.py
@@ -19,7 +19,7 @@ def mainnet_fork_contract_instance(owner, contract_container, mainnet_fork_provi
 
 @pytest.mark.fork
 def test_multiple_providers(
-    name, networks, connected_provider, mainnet_fork_port, goerli_fork_port
+    name, networks, connected_provider, mainnet_fork_port, sepolia_fork_port
 ):
     assert networks.active_provider.name == name
     assert networks.active_provider.network.name == LOCAL_NETWORK_NAME
@@ -32,12 +32,12 @@ def test_multiple_providers(
         assert networks.active_provider.network.name == "mainnet-fork"
         assert networks.active_provider.port == mainnet_fork_port
 
-        with networks.ethereum.goerli_fork.use_provider(
-            name, provider_settings={"port": goerli_fork_port}
+        with networks.ethereum.sepolia_fork.use_provider(
+            name, provider_settings={"port": sepolia_fork_port}
         ):
             assert networks.active_provider.name == name
-            assert networks.active_provider.network.name == "goerli-fork"
-            assert networks.active_provider.port == goerli_fork_port
+            assert networks.active_provider.network.name == "sepolia-fork"
+            assert networks.active_provider.port == sepolia_fork_port
 
         assert networks.active_provider.name == name
         assert networks.active_provider.network.name == "mainnet-fork"
@@ -103,7 +103,7 @@ def test_get_receipt(mainnet_fork_provider, mainnet_fork_contract_instance, owne
 
 @pytest.mark.fork
 def test_unlock_account_with_multiple_providers(
-    networks, connected_provider, mainnet_fork_port, goerli_fork_port
+    networks, connected_provider, mainnet_fork_port, sepolia_fork_port
 ):
     with networks.ethereum.mainnet_fork.use_provider(
         "ganache", provider_settings={"port": mainnet_fork_port}
@@ -111,8 +111,8 @@ def test_unlock_account_with_multiple_providers(
         imp_acc = connected_provider.account_manager[TEST_ADDRESS]
         assert isinstance(imp_acc, ImpersonatedAccount)
 
-        with networks.ethereum.goerli_fork.use_provider(
-            "ganache", provider_settings={"port": goerli_fork_port}
+        with networks.ethereum.sepolia_fork.use_provider(
+            "ganache", provider_settings={"port": sepolia_fork_port}
         ):
             imp_acc = connected_provider.account_manager[TEST_ADDRESS]
             assert isinstance(imp_acc, ImpersonatedAccount)


### PR DESCRIPTION
### What I did

https://blog.ethereum.org/2023/11/30/goerli-lts-update
https://www.alchemy.com/blog/goerli-faucet-deprecation

Goerli support on all networks is ending soon:
- February 16th - [Base Goerli](https://www.alchemy.com/blog/base-goerli-testnet-deprecation)
- March 7th - [Optimism Goerli](https://www.alchemy.com/blog/optimism-goerli-testnet-deprecation)
- March 18th - [Arbitrum Goerli](https://www.alchemy.com/blog/arbitrum-goerli-testnet-deprecation)
- April 1st - [Ethereum Goerli](https://www.alchemy.com/blog/ethereum-goerli-testnet-deprecation)
- April 6th - [Polygon zkEVM Goerli](https://www.alchemy.com/blog/polygon-zkevm-cardona-is-live)
- April 11th - [Starknet Goerli](https://www.alchemy.com/blog/starknet-sepolia-is-live)
- April 13th - [Polygon Mumbai](https://www.alchemy.com/blog/polygon-mumbai-testnet-deprecation)

### Checklist

- [ ] Passes all linting checks (pre-commit and CI jobs)
- [ ] New test cases have been added and are passing
- [ ] Documentation has been updated
- [ ] PR title follows [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) standard (will be automatically included in the changelog)
